### PR TITLE
✨ feat: 다음 추천 기능 구현

### DIFF
--- a/src/main/java/org/example/flow/controller/shop/ShopPlaceController.java
+++ b/src/main/java/org/example/flow/controller/shop/ShopPlaceController.java
@@ -70,15 +70,30 @@ public class ShopPlaceController {
     }
 
     // 💳 결제 확정 → 슬라이딩 지급
+    // 💳 결제 확정 → (1) AI 슬라이딩 지급 → (2) 방문소진 + 다음추천 생성
     @PostMapping(
             value = "/payment/confirm",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public Map<String, Object> confirmPayment(@RequestBody @Valid PaymentConfirmRequest req) {
-        // 콘솔에서 어떤 Verifier가 물렸는지 확인용
-        return paymentConfirmService.confirm(req.userId(), req.shopInfoId());
+    public ResponseEntity<Map<String, Object>> confirmPayment(@RequestBody @Valid PaymentConfirmRequest req) {
+        /* ───────── 권장(A): DTO에 금액/확정 여부가 있는 경우 ───────── */
+        Map<String, Object> result = paymentConfirmService.confirm(
+                req.userId(),
+                req.shopInfoId(),
+                req.amount()
+        );
+
+        /* ───────── 대안(B): DTO에 금액/확정 여부가 없다면 아래로 교체 ─────────
+        Map<String, Object> result = paymentConfirmService.confirm(
+                req.userId(),
+                req.shopInfoId()
+        );
+        */
+
+        return ResponseEntity.ok(result);
     }
+
 
     // 📆 체크인 → (추천이면) 주간 카운트 증가 & 3/5회 보상
     @PostMapping("/shop/check-in")

--- a/src/main/java/org/example/flow/repository/RecommendShopRepository.java
+++ b/src/main/java/org/example/flow/repository/RecommendShopRepository.java
@@ -1,11 +1,18 @@
 package org.example.flow.repository;
 
+import jakarta.persistence.LockModeType;
 import org.example.flow.entity.RecommendShop;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
 public interface RecommendShopRepository extends JpaRepository<RecommendShop, Long> {
     Optional<RecommendShop> findTopByUser_UserIdOrderByCreatedAtDesc(Long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE) // ✅ 동시성 방지
+    Optional<RecommendShop>
+    findTopByUser_UserIdAndShopInfo_ShopInfoIdAndVisitedFalseOrderByCreatedAtDesc(Long userId, Long shopInfoId);
 }
+
 

--- a/src/main/java/org/example/flow/service/recommendation/AcceptPaymentVerifier.java
+++ b/src/main/java/org/example/flow/service/recommendation/AcceptPaymentVerifier.java
@@ -1,0 +1,30 @@
+package org.example.flow.service.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service("acceptPaymentVerifier")
+@RequiredArgsConstructor
+public class AcceptPaymentVerifier implements RecommendationVerifier {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public boolean isRecommended(Long userId, Long shopInfoId, @org.springframework.lang.Nullable String ignore) {
+        // 최신 결제 상태가 ACCEPT 인지 확인
+        final String sql = """
+            SELECT CASE WHEN status = 'ACCEPT' THEN 1 ELSE 0 END AS ok
+            FROM payment_check
+            WHERE user_id = ? AND shop_info_id = ?
+            ORDER BY created_at DESC
+            LIMIT 1
+        """;
+        Boolean ok = jdbcTemplate.query(sql, ps -> {
+            ps.setLong(1, userId);
+            ps.setLong(2, shopInfoId);
+        }, rs -> rs.next() ? rs.getInt("ok") == 1 : false);
+
+        return Boolean.TRUE.equals(ok);
+    }
+}

--- a/src/main/java/org/example/flow/service/recommendation/PaymentConfirmService.java
+++ b/src/main/java/org/example/flow/service/recommendation/PaymentConfirmService.java
@@ -2,16 +2,35 @@ package org.example.flow.service.recommendation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentConfirmService {
-    private final RecommendationVerifier verifier;
 
-    public Map<String, Object> confirm(Long userId, Long shopInfoId) {
-        boolean aiPaymentRewarded = verifier.isRecommended(userId, shopInfoId, null);
-        return Map.of("aiPaymentRewarded", aiPaymentRewarded);
+    private final RecommendationVisitOrchestrator orchestrator;
+    private final RewardService rewardService;
+
+    @Transactional
+    public Map<String, Object> confirm(Long userId, Long shopInfoId, long paidAmount) {
+        Map<String, Object> res = new LinkedHashMap<>();
+
+        // 1) 방문 소진(추천-방문 매칭)
+        boolean matched = orchestrator.confirmVisitOnly(userId, shopInfoId);
+        res.put("matched", matched);
+
+        // 2) 보상: matched가 true일 때만 판단 (RewardService는 3인자)
+        boolean rewarded = matched && rewardService.awardAiRecommendedPayment(userId, shopInfoId, paidAmount);
+        res.put("aiPaymentRewarded", rewarded);
+
+        // 3) 보상 OK 시에만 다음 추천
+        if (rewarded) {
+            Long nextId = orchestrator.getNextRecommendShopId(userId);
+            res.put("nextRecommendShopId", nextId);
+        }
+        return res;
     }
 }

--- a/src/main/java/org/example/flow/service/recommendation/RecommendationVerifier.java
+++ b/src/main/java/org/example/flow/service/recommendation/RecommendationVerifier.java
@@ -1,6 +1,6 @@
 package org.example.flow.service.recommendation;
 
-import org.springframework.lang.Nullable;
+import org.springframework.lang.Nullable; // ← 요걸 권장 (micrometer 아님)
 
 public interface RecommendationVerifier {
     boolean isRecommended(Long userId, Long shopInfoId, @Nullable String evidence);

--- a/src/main/java/org/example/flow/service/recommendation/RecommendationVisitOrchestrator.java
+++ b/src/main/java/org/example/flow/service/recommendation/RecommendationVisitOrchestrator.java
@@ -1,0 +1,76 @@
+package org.example.flow.service.recommendation;
+
+import lombok.RequiredArgsConstructor;
+import org.example.flow.entity.RecommendVisitLog;
+import org.example.flow.entity.Visited;
+import org.example.flow.entity.ShopInfo;
+import org.example.flow.repository.*;
+import org.example.flow.service.recommendShop.ShopRecommendationService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+
+@Service
+@RequiredArgsConstructor
+public class RecommendationVisitOrchestrator {
+
+    private final RecommendShopRepository recommendShopRepository;
+    private final VisitedRepository visitedRepository;
+    private final RecommendVisitLogRepository visitLogRepository;
+    private final UserRepository userRepository;
+    private final ShopInfoRepository shopInfoRepository;
+    private final ShopRecommendationService shopRecommendationService;
+
+    @Transactional
+    public boolean confirmVisitOnly(Long userId, Long shopInfoId) {
+        var opt = recommendShopRepository
+                .findTopByUser_UserIdAndShopInfo_ShopInfoIdAndVisitedFalseOrderByCreatedAtDesc(userId, shopInfoId);
+        if (opt.isEmpty()) return false;
+
+        var now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+
+        // 1) 추천 소진
+        var rs = opt.get();
+        rs.setVisited(true);
+        rs.setVisitedAt(now);
+
+        // 2) visited INSERT (setter 방식)
+        var userRef = userRepository.getReferenceById(userId);
+        var shopRef = shopInfoRepository.getReferenceById(shopInfoId);
+        var v = new Visited();
+        v.setUser(userRef);
+        v.setShopInfo(shopRef);
+        v.setCreatedAt(now);
+        visitedRepository.save(v);
+
+        // 3) 주간 로그 upsert (RecommendVisitLog = weekStart, visitCount만 사용)
+        upsertWeeklyVisitLog(userId, now.toLocalDate());
+
+        return true;
+    }
+
+    @Transactional
+    public Long getNextRecommendShopId(Long userId) {
+        var user = userRepository.getReferenceById(userId);
+        var next = shopRecommendationService.recommendShop(user, LocalDateTime.now(ZoneId.of("Asia/Seoul")));
+        return next != null ? next.getShopInfoId() : null;
+    }
+
+    private void upsertWeeklyVisitLog(Long userId, LocalDate today) {
+        // 월요일 시작 주차
+        LocalDate weekStart = today.minusDays((today.getDayOfWeek().getValue() + 6) % 7);
+
+        var log = visitLogRepository.findByUser_UserIdAndWeekStart(userId, weekStart)
+                .orElseGet(() -> {
+                    var nl = new RecommendVisitLog();
+                    nl.setUser(userRepository.getReferenceById(userId));
+                    nl.setWeekStart(weekStart);
+                    nl.setVisitCount(0);
+                    return nl;
+                });
+
+        log.setVisitCount(log.getVisitCount() + 1);
+        visitLogRepository.save(log);
+    }
+}

--- a/src/main/java/org/example/flow/service/recommendation/RewardService.java
+++ b/src/main/java/org/example/flow/service/recommendation/RewardService.java
@@ -3,22 +3,31 @@ package org.example.flow.service.recommendation;
 import lombok.RequiredArgsConstructor;
 import org.example.flow.entity.Profile;
 import org.example.flow.repository.ProfileRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class RewardService {
 
     private final ProfileRepository profileRepository;
-    private final RecommendationVerifier recommendationVerifier; // 현재 추천 여부 재검증
+    private final RecommendationVerifier recommendationVerifier;
     private final WeeklyAiVisitCounterService weeklyAiVisitCounterService; // 아래 2) 참고
+
+    public RewardService(
+            ProfileRepository profileRepository,
+            @Qualifier("acceptPaymentVerifier") RecommendationVerifier recommendationVerifier, // ← 여기!
+            WeeklyAiVisitCounterService weeklyAiVisitCounterService
+    ) {
+        this.profileRepository = profileRepository;
+        this.recommendationVerifier = recommendationVerifier;
+        this.weeklyAiVisitCounterService = weeklyAiVisitCounterService;
+    }
 
     /* ───────── 💳 AI 추천 매장 결제: 금액 구간 슬라이딩 ───────── */
     public boolean awardAiRecommendedPayment(Long userId, Long shopInfoId, long paidAmount) {
-        if (!recommendationVerifier.isRecommended(userId, shopInfoId, null)) return false;
-
+        if (!recommendationVerifier.isRecommended(userId, shopInfoId, null)) return false; // ✅ now=null 허용
         int pts = calcAiPaymentPoints(paidAmount);
         addPoint(userId, pts, "AI 추천매장 결제 리워드(슬라이딩)");
         return true;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #55 

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- 추천 → 방문확인 → 다음 추천
방문확인됐을 때 추천매장이면 추천매장 visited=true로 바꾸고 다음 추천매장 추천하는 방식
호출용 코드 ShopInfo recommended = shopRecommendationService.recommendShop(user, LocalDateTime.now()); 사용
recommendShop DB에 로우가 추가로 쌓이게 구
추천매장 visit하면 visited와 recommend_visit_log와 recommend_shop 총 3개에 변화

## 💬 기타
<!-- 참고할 내용 -->
아 머리아파


## ✅ 체크 리스트
- [x] devleop 브랜치 pull 완료
- [x] Assignees 설정